### PR TITLE
Performance improvements for Android

### DIFF
--- a/src/XamarinBackgroundKit.Android/BackgroundKit.cs
+++ b/src/XamarinBackgroundKit.Android/BackgroundKit.cs
@@ -1,7 +1,12 @@
-﻿namespace XamarinBackgroundKit.Android
+﻿using Android.Graphics;
+
+namespace XamarinBackgroundKit.Android
 {
     public static class BackgroundKit
     {
+        public static readonly PorterDuffXfermode PorterDuffClearMode =
+            new PorterDuffXfermode(PorterDuff.Mode.Clear);
+
         public static void Init() { }
     }
 }

--- a/src/XamarinBackgroundKit.Android/Renderers/CornerOutlineProvider.cs
+++ b/src/XamarinBackgroundKit.Android/Renderers/CornerOutlineProvider.cs
@@ -24,10 +24,11 @@ namespace XamarinBackgroundKit.Android.Renderers
                 return;
             }
 
-            var roundPath = new Path();
-            roundPath.AddRoundRect(0, 0, view.Width, view.Height, _cornerRadii, Path.Direction.Cw);
-
-            outline.SetConvexPath(roundPath);
+            using (var roundPath = new Path())
+            {
+                roundPath.AddRoundRect(0, 0, view.Width, view.Height, _cornerRadii, Path.Direction.Cw);
+                outline.SetConvexPath(roundPath);
+            }
         }
     }
 }

--- a/src/XamarinBackgroundKit.Android/Renderers/MaterialBackgroundManager.cs
+++ b/src/XamarinBackgroundKit.Android/Renderers/MaterialBackgroundManager.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using Android.Content;
 using Android.Content.Res;
 using Android.Graphics.Drawables;
+using Android.OS;
 using Android.Runtime;
 using Android.Support.Design.Button;
 using Android.Support.Design.Card;
@@ -265,7 +266,7 @@ namespace XamarinBackgroundKit.Android.Renderers
                     break;
                 case MaterialButton mButton:
                     var primaryColor = color.ToAndroid();
-                    var alphaPrimaryColor = new global::Android.Graphics.Color(
+                    var alphaPrimaryColor = new AColor(
                         primaryColor.R, primaryColor.G, primaryColor.B, (byte)(0.12 * 255));
                     ViewCompat.SetBackgroundTintList(mButton,
                         new ColorStateList(ButtonStates, new int[] { primaryColor, alphaPrimaryColor }));
@@ -329,6 +330,8 @@ namespace XamarinBackgroundKit.Android.Renderers
 
         private void UpdateRipple()
         {
+            if (Build.VERSION.SdkInt <= BuildVersionCodes.LollipopMr1) return;
+
             if (_nativeView == null || _backgroundElement == null) return;
             if (_nativeView is MaterialCardView || _nativeView is Chip || _nativeView is MaterialButton) return;
 


### PR DESCRIPTION
* Fixes #38 
* Optimized Android drawing. Reducing bitmap allocations, from 2 bitmaps to 0
* Reducing GradientStrokeDrawable Stroke object allocations. Lazy initialization when stroke is set
* ClipPathManager no longer uses ```Canvas.ClipPath``` and provides anti-aliased clipping